### PR TITLE
Set ONLY_ACTIVE_ARCH to NO for debug config

### DIFF
--- a/TrustKit.xcodeproj/project.pbxproj
+++ b/TrustKit.xcodeproj/project.pbxproj
@@ -637,6 +637,7 @@
 					"$(PROJECT_DIR)/TrustKit",
 					"$(PROJECT_DIR)/TrustKit/Dependencies/domain_registry",
 				);
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = "$(inherited)";
@@ -732,6 +733,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/TrustKit/Dependencies/domain_registry",
 				);
+				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = "$(inherited)";


### PR DESCRIPTION
Allows multiple architectures to be built with the debug configuration