### PR TITLE
Fixed documentation example, where we would not enforce pinning.

### DIFF
--- a/TrustKit/Pinning/public_key_utils.m
+++ b/TrustKit/Pinning/public_key_utils.m
@@ -79,7 +79,7 @@ static NSData *getPublicKeyDataFromCertificate(SecCertificateRef certificate)
     
     
     // Extract the actual bytes from the key reference using the Keychain
-    // Prepare the dictionnary to add the key
+    // Prepare the dictionary to add the key
     NSMutableDictionary *peerPublicKeyAdd = [[NSMutableDictionary alloc] init];
     [peerPublicKeyAdd setObject:(__bridge id)kSecClassKey forKey:(__bridge id)kSecClass];
     [peerPublicKeyAdd setObject:kTSKKeychainPublicKeyTag forKey:(__bridge id)kSecAttrApplicationTag];
@@ -91,7 +91,7 @@ static NSData *getPublicKeyDataFromCertificate(SecCertificateRef certificate)
     // Request the key's data to be returned
     [peerPublicKeyAdd setObject:(__bridge id)(kCFBooleanTrue) forKey:(__bridge id)kSecReturnData];
     
-    // Prepare the dictionnary to retrieve and delete the key
+    // Prepare the dictionary to retrieve and delete the key
     NSMutableDictionary * publicKeyGet = [[NSMutableDictionary alloc] init];
     [publicKeyGet setObject:(__bridge id)kSecClassKey forKey:(__bridge id)kSecClass];
     [publicKeyGet setObject:(kTSKKeychainPublicKeyTag) forKey:(__bridge id)kSecAttrApplicationTag];

--- a/TrustKit/TrustKit.h
+++ b/TrustKit/TrustKit.h
@@ -59,7 +59,7 @@ FOUNDATION_EXPORT const NSString * kTSKAlgorithmEcDsaSecp256r1;
  | ____ `TSKReportUris`                         | Array      |
  | ____ `kTSKDisableDefaultReportUri`           | Boolean    |
  
- When setting the pinning policy programmatically, it has to be supplied to the `initializeWithConfiguration:` method as a dictionnary. For example:
+ When setting the pinning policy programmatically, it has to be supplied to the `initializeWithConfiguration:` method as a dictionary. For example:
  
     NSDictionary *trustKitConfig =
     @{
@@ -203,7 +203,7 @@ FOUNDATION_EXPORT const NSString * kTSKAlgorithmEcDsaSecp256r1;
  
  This method should be called as early as possible in the App's lifecycle to ensure that the App's very first SSL connections are validated by TrustKit.
  
- @param trustKitConfig A dictionnary containing various keys for configuring the global SSL pinning policy.
+ @param trustKitConfig A dictionary containing various keys for configuring the global SSL pinning policy.
  @exception NSException Thrown when the supplied configuration is invalid or TrustKit has already been initialized.
  
  */

--- a/TrustKit/TrustKit.m
+++ b/TrustKit/TrustKit.m
@@ -43,7 +43,7 @@ const NSString *kTSKAlgorithmEcDsaSecp256r1 = @"TSKAlgorithmEcDsaSecp256r1";
 
 
 #pragma mark TrustKit Global State
-// Global dictionnary for storing the public key hashes and domains
+// Global dictionary for storing the public key hashes and domains
 static NSDictionary *_trustKitGlobalConfiguration = nil;
 
 // Global preventing multiple initializations (double function interposition, etc.)
@@ -121,7 +121,7 @@ void sendPinFailureReport_async(TSKPinValidationResult validationResult, SecTrus
 
 NSDictionary *parseTrustKitArguments(NSDictionary *TrustKitArguments)
 {
-    // Convert settings supplied by the user to a configuration dictionnary that can be used by TrustKit
+    // Convert settings supplied by the user to a configuration dictionary that can be used by TrustKit
     // This includes checking the sanity of the settings and converting public key hashes/pins from an
     // NSSArray of NSStrings (as provided by the user) to an NSSet of NSData (as needed by TrustKit)
     

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,7 +117,7 @@ corresponding certificates' public key algorithms. For example:
                       kTSKIncludeSubdomains:@YES,
                       
                       // Do not block connections if pinning validation failed so the App doesn't break
-                      kTSKEnforcePinning:@YES,
+                      kTSKEnforcePinning:@NO,
                     
                       // Send reports for pin validation failures so we can track them
                       kTSKReportUris: @[@"https://trustkit-reports-server.appspot.com/log_report"],


### PR DESCRIPTION
Fixed documentation example, where we would not enforce pinning.
Also, fixed "dictionnary" typos.