### PR TITLE
Added TRUSTKIT_SKIP_LIB_INITIALIZATION

### DIFF
--- a/TrustKit/TrustKit.m
+++ b/TrustKit/TrustKit.m
@@ -420,6 +420,11 @@ static void initializeTrustKit(NSDictionary *trustKitConfig)
 
 #pragma mark TrustKit Implicit Initialization via Library Constructor
 
+// TRUSTKIT_SKIP_LIB_INITIALIZATION define allows consumers to opt out of the dylib constructor.
+// This might be useful to mitigate integration risks, if the consumer doens't wish to use
+// plist file, and wants to initialize lib manually later on.
+#ifndef TRUSTKIT_SKIP_LIB_INITIALIZATION
+
 __attribute__((constructor)) static void initializeWithInfoPlist(int argc, const char **argv)
 {
     // TrustKit just got started in the App
@@ -434,5 +439,4 @@ __attribute__((constructor)) static void initializeWithInfoPlist(int argc, const
     }
 }
 
-
-
+#endif


### PR DESCRIPTION
This optional macro define allows consumers to opt-out from dylib constructor Info.plist auto-initialization.
When TRUSTKIT_SKIP_LIB_INITIALIZATION is set, Info.plist is not auto-loaded and parsed, and the consumers need to initialize TrustKit manually.