### PR TITLE
Fixed unit tests for expired/invalid certificates

### DIFF
--- a/TrustKitTests/TSKCertificateUtils.m
+++ b/TrustKitTests/TSKCertificateUtils.m
@@ -69,6 +69,15 @@
     }
     
     CFRelease(certificateChain);
+
+    // Certificates included in the test suite have certain expiration time window - between 11/3/15 and 3/29/16
+    // Set the verify date to be in that range so the certs do not need to be updated periodically
+    // The date we set to is 2016-01-22
+    CFAbsoluteTime verifyTime = 475163640.0;
+    CFDateRef testVerifyDate = CFDateCreate(NULL, verifyTime);
+    SecTrustSetVerifyDate(trust, testVerifyDate);
+    CFRelease(testVerifyDate);
+
     return trust;
 }
 

--- a/TrustKitTests/TSKNSURLConnectionTests.m
+++ b/TrustKitTests/TSKNSURLConnectionTests.m
@@ -303,8 +303,8 @@
           @{
               @"www.twitter.com" : @{
                       kTSKPublicKeyAlgorithms : @[kTSKAlgorithmRsa2048],
-                      kTSKPublicKeyHashes : @[@"JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=", // CA key
-                                              @"JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=" // CA key
+                      kTSKPublicKeyHashes : @[@"RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=", // CA key
+                                              @"RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=" // CA key
                                               ]}}};
     
     [TrustKit initializeWithConfiguration:trustKitConfig];


### PR DESCRIPTION
1. Fixed testPinningValidationSucceeded to pin to a new twitter.com CA
2. Good.com and related certificates included with the test suite have expired. Fixed by specifying a validation date to be in the valid time window.