### PR TITLE
Update the key to persiste the SPKI

### DIFF
--- a/TrustKit/Pinning/public_key_utils.m
+++ b/TrustKit/Pinning/public_key_utils.m
@@ -162,10 +162,13 @@ NSData *hashSubjectPublicKeyInfoFromCertificate(SecCertificateRef certificate, T
     
     // Have we seen this certificate before? Look for the SPKI in the cache
     NSData *certificateData = (__bridge NSData *)(SecCertificateCopyData(certificate));
+    
+    NSMutableData *certificateDataWithAlgorithm = [NSMutableData dataWithData:certificateData];
+    [certificateDataWithAlgorithm appendData:[NSData dataWithBytes:&publicKeyAlgorithm length:sizeof(int)]];
 
     pthread_mutex_lock(&_spkiCacheLock);
     {
-        cachedSubjectPublicKeyInfo = _subjectPublicKeyInfoHashesCache[certificateData];
+        cachedSubjectPublicKeyInfo = _subjectPublicKeyInfoHashesCache[certificateDataWithAlgorithm];
     }
     pthread_mutex_unlock(&_spkiCacheLock);
     
@@ -205,7 +208,7 @@ NSData *hashSubjectPublicKeyInfoFromCertificate(SecCertificateRef certificate, T
     // Store the hash in our memory cache
     pthread_mutex_lock(&_spkiCacheLock);
     {
-        _subjectPublicKeyInfoHashesCache[certificateData] = subjectPublicKeyInfoHash;
+        _subjectPublicKeyInfoHashesCache[certificateDataWithAlgorithm] = subjectPublicKeyInfoHash;
     }
     pthread_mutex_unlock(&_spkiCacheLock);
     


### PR DESCRIPTION
Update the key to persist the SPKI with a salt representing the algorithm instead of using only the certificate data

Issue reported here #50 