### PR TITLE
Added switch to enable or disable logging

### DIFF
--- a/TrustKit/TrustKit.h
+++ b/TrustKit/TrustKit.h
@@ -275,6 +275,16 @@ typedef void(*TSKLoggerMethod) (NSString *logMessage);
  @return A dictionary with a copy of the current TrustKit configuration, or `nil` if TrustKit has not been initialized.
  */
 + (nullable NSDictionary *) configuration;
+
+///----------------------------
+/// @name Logging
+///----------------------------
+
+/**
+ Set a logging method to log TrustKit logs in release mode
+ 
+ @param method A function pointer to log TrustKit log messages in release mode or `nil` to stop logging in release mode 
+ */
 + (void)setLoggerMethod:(TSKLoggerMethod)method;
 
 @end

--- a/TrustKit/TrustKit.h
+++ b/TrustKit/TrustKit.h
@@ -15,11 +15,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 
-#pragma mark TrustKit Version Number
+#pragma mark - TrustKit Version Number
 FOUNDATION_EXPORT NSString * const TrustKitVersion;
 
 
-#pragma mark TrustKit Configuration Keys
+#pragma mark - TrustKit Configuration Keys
 
 FOUNDATION_EXPORT NSString * const kTSKSwizzleNetworkDelegates;
 FOUNDATION_EXPORT NSString * const kTSKPinnedDomains;
@@ -32,14 +32,14 @@ FOUNDATION_EXPORT NSString * const kTSKDisableDefaultReportUri;
 FOUNDATION_EXPORT NSString * const kTSKIgnorePinningForUserDefinedTrustAnchors NS_AVAILABLE_MAC(10_9);
 
 
-#pragma mark Supported Public Key Algorithm Keys
+#pragma mark - Supported Public Key Algorithm Keys
 
 FOUNDATION_EXPORT NSString * const kTSKAlgorithmRsa2048;
 FOUNDATION_EXPORT NSString * const kTSKAlgorithmRsa4096;
 FOUNDATION_EXPORT NSString * const kTSKAlgorithmEcDsaSecp256r1;
 
 
-#pragma mark TrustKit Notifications
+#pragma mark - TrustKit Notifications
 // This notification is posted for every request that's going through TrustKit pinning validation
 FOUNDATION_EXPORT NSString * const kTSKValidationCompletedNotification;
 
@@ -50,6 +50,9 @@ FOUNDATION_EXPORT NSString * const kTSKValidationDecisionNotificationKey;
 FOUNDATION_EXPORT NSString * const kTSKValidationCertificateChainNotificationKey;
 FOUNDATION_EXPORT NSString * const kTSKValidationNotedHostnameNotificationKey;
 FOUNDATION_EXPORT NSString * const kTSKValidationServerHostnameNotificationKey;
+
+#pragma mark - logger method type
+typedef void(*TSKLoggerMethod) (NSString *logMessage);
 
 /**
  `TrustKit` is a class for programmatically configuring the global SSL pinning policy within an App.
@@ -272,6 +275,7 @@ FOUNDATION_EXPORT NSString * const kTSKValidationServerHostnameNotificationKey;
  @return A dictionary with a copy of the current TrustKit configuration, or `nil` if TrustKit has not been initialized.
  */
 + (nullable NSDictionary *) configuration;
++ (void)setLoggerMethod:(TSKLoggerMethod)method;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/TrustKit/TrustKit.m
+++ b/TrustKit/TrustKit.m
@@ -83,14 +83,21 @@ void TSKLog(NSString *format, ...)
     NSString *newFormat = [[NSString alloc] initWithFormat:@"=== TrustKit: %@", format];
     va_list args;
     va_start(args, format);
-    NSLogv(newFormat, args);
+    if(_loggerMethod) {
+        // log using the method set by application
+        NSString *logMsg = [[NSString alloc] initWithFormat:newFormat arguments:args];
+        _loggerMethod(logMsg);
+    }
+    else {
+        NSLogv(newFormat, args);
+    }
     va_end(args);
 #else
     // Check if the app/framework user wants logs or not
     if(_loggerMethod) {
+        NSString *newFormat = [[NSString alloc] initWithFormat:@"=== TrustKit: %@", format];
         va_list args;
         va_start(args, format);
-        NSString *newFormat = [[NSString alloc] initWithFormat:@"=== TrustKit: %@", format];
         NSString *logMsg = [[NSString alloc] initWithFormat:newFormat arguments:args];
         _loggerMethod(logMsg);
         va_end(args);

--- a/TrustKit/TrustKit.m
+++ b/TrustKit/TrustKit.m
@@ -73,17 +73,28 @@ static id _pinValidationObserver = nil;
 static NSString * const kTSKDefaultReportUri = @"https://overmind.datatheorem.com/trustkit/report";
 
 
-#pragma mark Logging Function
+#pragma mark - Logging Function
+static TSKLoggerMethod _loggerMethod = NULL;
 
 void TSKLog(NSString *format, ...)
 {
-    // Only log in debug builds
 #if DEBUG
+    // Only log in debug builds
     NSString *newFormat = [[NSString alloc] initWithFormat:@"=== TrustKit: %@", format];
     va_list args;
     va_start(args, format);
     NSLogv(newFormat, args);
     va_end(args);
+#else
+    // Check if the app/framework user wants logs or not
+    if(_loggerMethod) {
+        va_list args;
+        va_start(args, format);
+        NSString *newFormat = [[NSString alloc] initWithFormat:@"=== TrustKit: %@", format];
+        NSString *logMsg = [[NSString alloc] initWithFormat:newFormat arguments:args];
+        _loggerMethod(logMsg);
+        va_end(args);
+    }
 #endif
 }
 
@@ -271,6 +282,11 @@ static void initializeTrustKit(NSDictionary *trustKitConfig)
 + (void) setGlobalPinFailureReporter:(TSKBackgroundReporter *) reporter
 {
     _pinFailureReporter = reporter;
+}
+
++ (void)setLoggerMethod:(TSKLoggerMethod)method
+{
+    _loggerMethod = method;
 }
 
 @end


### PR DESCRIPTION
This merge should fix [this](https://github.com/datatheorem/TrustKit/issues/52) issue.

User can use following code to enable the logging in release mode:
```objc
...
[TrustKit setLoggerMethod:logTrustKit];
...
void logTrustKit(NSString * logMessage) {
#if DEBUG
    NSLog(@"%@", logMessage)
#else
    DDLogVerbose(@"%@", logMessage);
#endif
}
```

User can use following code to disable the logging in release mode:
```objc
...
[TrustKit setLoggerMethod:NULL];
...
```