### PR TITLE
Don’t try to unarchive a nil data object during SPKI cache loading.

### DIFF
--- a/TrustKit/Pinning/public_key_utils.m
+++ b/TrustKit/Pinning/public_key_utils.m
@@ -372,10 +372,12 @@ void resetSubjectPublicKeyInfoCache(void)
 
 NSMutableDictionary<NSNumber *, SpkiCacheDictionnary *> *getSpkiCacheFromFileSystem(void)
 {
-    NSMutableDictionary *spkiCache;
+    NSMutableDictionary *spkiCache = nil;
     NSString *spkiCachePath = [[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0] stringByAppendingPathComponent:_spkiCacheFilename];
     NSData *serializedSpkiCache = [NSData dataWithContentsOfFile:spkiCachePath];
-    spkiCache = [NSKeyedUnarchiver unarchiveObjectWithData:serializedSpkiCache];
+    if (serializedSpkiCache) {
+        spkiCache = [NSKeyedUnarchiver unarchiveObjectWithData:serializedSpkiCache];
+    }
     return spkiCache;
 }
 


### PR DESCRIPTION
See https://github.com/datatheorem/TrustKit/issues/95

Calling `[NSKeyedUnarchiver unarchiveObjectWithData:]` with a nil data object causes the following error messages on the console:
> *** -[NSKeyedUnarchiver initForReadingWithData:]: data is NULL

This should actually considered to be a critical error since the method expects a valid data object according to the [documentation.](https://developer.apple.com/reference/foundation/nskeyedunarchiver/1413894-unarchiveobjectwithdata?language=objc)