### PR TITLE
Adjust OpenSSL command redirections in get_pin_from_certificate.py to work on Windows systems

### DIFF
--- a/get_pin_from_certificate.py
+++ b/get_pin_from_certificate.py
@@ -7,7 +7,7 @@ import os.path
 import argparse
 import hashlib
 import base64
-
+import platform
 
 class SupportedKeyAlgorithmsEnum(object):
     RSA_2048 = 1
@@ -81,9 +81,13 @@ if __name__ == '__main__':
     else:
         raise ValueError('Unexpected key algorithm')
 
+    if platform.system() == 'Windows':
+        cmd_redirects = '2>nul'
+    else:
+        cmd_redirects = '-in /dev/stdin 2>/dev/null'
+        
     p1 = Popen('openssl x509  -pubkey -noout -inform {} '
-               '| openssl {} -outform DER -pubin -in /dev/stdin 2>/dev/null'.format(args.type,
-                                                                                       openssl_alg),
+               '| openssl {} -outform DER -pubin {}'.format(args.type, openssl_alg, cmd_redirects),
             shell=True, stdin=PIPE, stdout=PIPE)
     spki = p1.communicate(input=certificate)[0]
 


### PR DESCRIPTION
The utility script `get_pin_from_certificate.py` is also useful to obtain pins in Windows platforms.
I made small changes to the way the redirections were being done while calling the OpenSSL executable for it to work in Windows. 

In the pull request I added platform detection ('Windows' vs all others) to make it work in most platforms.
I checked if the Android version was a better place to introduce these changes, but the script is only available in the iOS repository.