### PR TITLE
Some minor improvements. If setLoggerBlock is not called, and not

### DIFF
--- a/TrustKit.xcodeproj/project.pbxproj
+++ b/TrustKit.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		FC4CAC7B1E958E0500DAC41E /* TSKReportsRateLimiterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FC4CAC7A1E958E0500DAC41E /* TSKReportsRateLimiterTests.m */; };
 		FC4CAC7C1E96891A00DAC41E /* TSKReportsRateLimiterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FC4CAC7A1E958E0500DAC41E /* TSKReportsRateLimiterTests.m */; };
 		FC4CAC7D1E96891B00DAC41E /* TSKReportsRateLimiterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FC4CAC7A1E958E0500DAC41E /* TSKReportsRateLimiterTests.m */; };
+		FCBF75E41F0F4C97004A74AB /* TSKPinningValidatorCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CF27A921F0185EC009369B0 /* TSKPinningValidatorCallback.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FCC1DD081EECD19E00AB3D81 /* anchor-ca.cert.pem in Resources */ = {isa = PBXBuildFile; fileRef = FCC1DD051EECD19E00AB3D81 /* anchor-ca.cert.pem */; };
 		FCC1DD091EECD19E00AB3D81 /* anchor-fake.yahoo.com.cert.pem in Resources */ = {isa = PBXBuildFile; fileRef = FCC1DD061EECD19E00AB3D81 /* anchor-fake.yahoo.com.cert.pem */; };
 		FCC1DD0A1EECD19E00AB3D81 /* anchor-intermediate.cert.pem in Resources */ = {isa = PBXBuildFile; fileRef = FCC1DD071EECD19E00AB3D81 /* anchor-intermediate.cert.pem */; };
@@ -831,6 +832,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FCBF75E41F0F4C97004A74AB /* TSKPinningValidatorCallback.h in Headers */,
 				8C84CCDA1D6E5D5A009B3E7D /* registry_types.h in Headers */,
 				FC1A09001E57A4BB0055B12C /* TSKPinningValidatorResult.h in Headers */,
 				FCE7D6321EE9FDFD0081EEEF /* TSKPublicKeyAlgorithm.h in Headers */,

--- a/TrustKit/Reporting/vendor_identifier.h
+++ b/TrustKit/Reporting/vendor_identifier.h
@@ -1,10 +1,13 @@
-//
-//  vendor_identifier.h
-//  TrustKit
-//
-//  Created by Alban Diquet on 8/24/16.
-//  Copyright © 2016 TrustKit. All rights reserved.
-//
+/*
+ 
+ vendor_identifier.h
+ TrustKit
+ 
+ Copyright 2016 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 @import Foundation;
 

--- a/TrustKit/Reporting/vendor_identifier.m
+++ b/TrustKit/Reporting/vendor_identifier.m
@@ -1,10 +1,13 @@
-//
-//  vendor_identifier.m
-//  TrustKit
-//
-//  Created by Alban Diquet on 8/24/16.
-//  Copyright © 2016 TrustKit. All rights reserved.
-//
+/*
+ 
+ vendor_identifier.m
+ TrustKit
+ 
+ Copyright 2016 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 #import "vendor_identifier.h"
 

--- a/TrustKit/Swizzling/TSKNSURLConnectionDelegateProxy.h
+++ b/TrustKit/Swizzling/TSKNSURLConnectionDelegateProxy.h
@@ -1,10 +1,13 @@
-//
-//  TSKNSURLConnectionDelegateProxy.h
-//  TrustKit
-//
-//  Created by Alban Diquet on 10/7/15.
-//  Copyright © 2015 TrustKit. All rights reserved.
-//
+/*
+ 
+ TSKNSURLConnectionDelegateProxy.h
+ TrustKit
+ 
+ Copyright 2015 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 @import Foundation;
 

--- a/TrustKit/Swizzling/TSKNSURLConnectionDelegateProxy.m
+++ b/TrustKit/Swizzling/TSKNSURLConnectionDelegateProxy.m
@@ -1,10 +1,13 @@
-//
-//  TSKNSURLConnectionDelegateProxy.m
-//  TrustKit
-//
-//  Created by Alban Diquet on 10/7/15.
-//  Copyright © 2015 TrustKit. All rights reserved.
-//
+/*
+ 
+ TSKNSURLConnectionDelegateProxy.h
+ TrustKit
+ 
+ Copyright 2015 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 #import "TSKNSURLConnectionDelegateProxy.h"
 #import "../TrustKit.h"

--- a/TrustKit/Swizzling/TSKNSURLSessionDelegateProxy.h
+++ b/TrustKit/Swizzling/TSKNSURLSessionDelegateProxy.h
@@ -1,10 +1,13 @@
-//
-//  TSKNSURLSessionDelegateProxy.h
-//  TrustKit
-//
-//  Created by Alban Diquet on 10/11/15.
-//  Copyright © 2015 TrustKit. All rights reserved.
-//
+/*
+ 
+ TSKNSURLSessionDelegateProxy.h
+ TrustKit
+ 
+ Copyright 2015 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 @import Foundation;
 

--- a/TrustKit/Swizzling/TSKNSURLSessionDelegateProxy.m
+++ b/TrustKit/Swizzling/TSKNSURLSessionDelegateProxy.m
@@ -1,10 +1,13 @@
-//
-//  TSKNSURLSessionDelegateProxy.m
-//  TrustKit
-//
-//  Created by Alban Diquet on 10/11/15.
-//  Copyright © 2015 TrustKit. All rights reserved.
-//
+/*
+ 
+ TSKNSURLSessionDelegateProxy.m
+ TrustKit
+ 
+ Copyright 2015 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 #import "TSKNSURLSessionDelegateProxy.h"
 #import "../TrustKit.h"

--- a/TrustKit/TSKPinningValidatorCallback.h
+++ b/TrustKit/TSKPinningValidatorCallback.h
@@ -1,10 +1,13 @@
-//
-//  TSKPinningValidatorCallback.h
-//  TrustKit
-//
-//  Created by Alban Diquet on 6/26/17.
-//  Copyright © 2017 TrustKit. All rights reserved.
-//
+/*
+ 
+ TSKPinningValidatorCallback.h
+ TrustKit
+ 
+ Copyright 2017 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 #ifndef TSKPinningValidatorCallback_h
 #define TSKPinningValidatorCallback_h

--- a/TrustKit/TSKPinningValidatorCallback.h
+++ b/TrustKit/TSKPinningValidatorCallback.h
@@ -43,7 +43,7 @@ typedef NSDictionary<TSKDomainConfigurationKey, id> TKSDomainPinningPolicy;
  Lastly, the callback is always invoked after the validation has been completed, and therefore
  cannot be used to modify the result of the validation (for example to accept invalid certificates).
  */
-typedef void (^TSKPinningValidatorCallback)(TSKPinningValidatorResult * _Nonnull, NSString * _Nonnull, TKSDomainPinningPolicy * _Nonnull);
+typedef void (^TSKPinningValidatorCallback)(TSKPinningValidatorResult * _Nonnull result, NSString * _Nonnull notedHostname, TKSDomainPinningPolicy * _Nonnull policy);
 
 
 

--- a/TrustKit/TSKPinningValidatorResult.m
+++ b/TrustKit/TSKPinningValidatorResult.m
@@ -42,7 +42,6 @@
         _evaluationResult = validationResult;
         _finalTrustDecision = finalTrustDecision;
         _validationDuration = validationDuration;
-        _certificateChain = nil;
     }
     return self;
 }

--- a/TrustKit/TSKPinningValidator_Private.h
+++ b/TrustKit/TSKPinningValidator_Private.h
@@ -6,9 +6,7 @@
 //  Copyright © 2017 TrustKit. All rights reserved.
 //
 
-#ifndef TSKPinningValidator_Private_h
-#define TSKPinningValidator_Private_h
-
+NS_ASSUME_NONNULL_BEGIN
 
 /* Methods that are internal to TrustKit */
 @interface TSKPinningValidator (Internal)
@@ -23,25 +21,23 @@
  @param validationCallback The callback invoked with validation results
  @return Initialized instance
  */
-- (instancetype _Nullable)initWithDomainPinningPolicies:(NSDictionary<NSString *, TKSDomainPinningPolicy *> *_Nonnull)domainPinningPolicies
-                                              hashCache:(TSKSPKIHashCache * _Nonnull)hashCache
+- (instancetype _Nullable)initWithDomainPinningPolicies:(NSDictionary<NSString *, TKSDomainPinningPolicy *> *)domainPinningPolicies
+                                              hashCache:(TSKSPKIHashCache *)hashCache
                           ignorePinsForUserTrustAnchors:(BOOL)ignorePinsForUserTrustAnchors
-                                validationCallbackQueue:(dispatch_queue_t _Nonnull)validationCallbackQueue
-                                     validationCallback:(TSKPinningValidatorCallback _Nonnull)validationCallback;
+                                validationCallbackQueue:(dispatch_queue_t)validationCallbackQueue
+                                     validationCallback:(TSKPinningValidatorCallback)validationCallback;
 
 @end
 
 
 @interface TSKPinningValidatorResult (Internal)
 
-- (instancetype _Nullable)initWithServerHostname:(NSString * _Nonnull)serverHostname
-                                     serverTrust:(SecTrustRef _Nonnull)serverTrust
+- (instancetype _Nullable)initWithServerHostname:(NSString *)serverHostname
+                                     serverTrust:(SecTrustRef)serverTrust
                                 validationResult:(TSKTrustEvaluationResult)validationResult
                               finalTrustDecision:(TSKTrustDecision)finalTrustDecision
                               validationDuration:(NSTimeInterval)validationDuration;
 
 @end
 
-
-#endif /* TSKPinningValidator_Private_h */
-
+NS_ASSUME_NONNULL_END

--- a/TrustKit/TSKPinningValidator_Private.h
+++ b/TrustKit/TSKPinningValidator_Private.h
@@ -1,10 +1,13 @@
-//
-//  TSKPinningValidator_Private.h
-//  TrustKit
-//
-//  Created by Alban Diquet on 6/23/17.
-//  Copyright © 2017 TrustKit. All rights reserved.
-//
+/*
+ 
+ TSKPinningValidator_Private.h
+ TrustKit
+ 
+ Copyright 2017 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/TrustKit/TSKTrustDecision.h
+++ b/TrustKit/TSKTrustDecision.h
@@ -8,6 +8,7 @@
  See AUTHORS file for the list of project authors.
  
  */
+
 @import Foundation;
 
 /**

--- a/TrustKit/TSKTrustKitConfig.h
+++ b/TrustKit/TSKTrustKitConfig.h
@@ -1,11 +1,13 @@
-//
-//  TSKTrustKitConfig.h
-//  TrustKit
-//
-//  Created by Adam Kaplan on 4/6/17.
-//  Copyright © 2017 TrustKit. All rights reserved.
-//
-
+/*
+ 
+ TSKTrustKitConfig.h
+ TrustKit
+ 
+ Copyright 2017 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 @import Foundation;
 

--- a/TrustKit/TSKTrustKitConfig.m
+++ b/TrustKit/TSKTrustKitConfig.m
@@ -1,10 +1,14 @@
-//
-//  TSKTrustKitConfig.h
-//  TrustKit
-//
-//  Created by Adam Kaplan on 4/6/17.
-//  Copyright © 2017 TrustKit. All rights reserved.
-//
+/*
+ 
+ TSKTrustKitConfig.m
+ TrustKit
+ 
+ Copyright 2017 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
+
 #import "TSKTrustKitConfig.h"
 
 NSString * const TrustKitVersion = @"1.5.0";

--- a/TrustKit/configuration_utils.h
+++ b/TrustKit/configuration_utils.h
@@ -1,10 +1,13 @@
-//
-//  configuration_utils.h
-//  TrustKit
-//
-//  Created by Alban Diquet on 2/20/17.
-//  Copyright © 2017 TrustKit. All rights reserved.
-//
+/*
+ 
+ configuration_utils.h
+ TrustKit
+ 
+ Copyright 2017 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 #import "TSKPinningValidatorCallback.h"
 

--- a/TrustKit/configuration_utils.m
+++ b/TrustKit/configuration_utils.m
@@ -1,10 +1,13 @@
-//
-//  configuration_utils.m
-//  TrustKit
-//
-//  Created by Alban Diquet on 2/20/17.
-//  Copyright © 2017 TrustKit. All rights reserved.
-//
+/*
+ 
+ configuration_utils.m
+ TrustKit
+ 
+ Copyright 2017 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 #import "configuration_utils.h"
 #import "TSKTrustKitConfig.h"

--- a/TrustKit/parse_configuration.h
+++ b/TrustKit/parse_configuration.h
@@ -1,10 +1,13 @@
-//
-//  parse_configuration.h
-//  TrustKit
-//
-//  Created by Alban Diquet on 5/20/16.
-//  Copyright © 2016 TrustKit. All rights reserved.
-//
+/*
+ 
+ parse_configuration.h
+ TrustKit
+ 
+ Copyright 2016 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 #ifndef parse_configuration_h
 #define parse_configuration_h

--- a/TrustKit/parse_configuration.m
+++ b/TrustKit/parse_configuration.m
@@ -1,10 +1,13 @@
-//
-//  parse_configuration.m
-//  TrustKit
-//
-//  Created by Alban Diquet on 5/20/16.
-//  Copyright © 2016 TrustKit. All rights reserved.
-//
+/*
+ 
+ parse_configuration.m
+ TrustKit
+ 
+ Copyright 2016 The TrustKit Project Authors
+ Licensed under the MIT license, see associated LICENSE file for terms.
+ See AUTHORS file for the list of project authors.
+ 
+ */
 
 #import "TSKTrustKitConfig.h"
 #import "Dependencies/domain_registry/domain_registry.h"

--- a/TrustKitDemo/TrustKitDemo/AppDelegate.m
+++ b/TrustKitDemo/TrustKitDemo/AppDelegate.m
@@ -12,7 +12,7 @@
 #import "AppDelegate.h"
 #import <TrustKit/TrustKit.h>
 #import <TrustKit/TSKPinningValidator.h>
-#import <TrustKit/TSKPinningValidatorResult.h>
+#import <TrustKit/TSKPinningValidatorCallback.h>
 
 @interface AppDelegate ()
 
@@ -30,7 +30,6 @@
 //        NSLog(@"TrustKit log: %@", message);
 //    };
 //    [TrustKit setLoggerBlock:loggerBlock];
-    
     
     // Initialize TrustKit
     NSDictionary *trustKitConfig =
@@ -71,14 +70,14 @@
                       }}};
     
     [TrustKit initializeWithConfiguration:trustKitConfig];
-
+    
     // Demonstrate how to receive pin validation notifications (only useful for performance/metrics)
-    [TrustKit sharedInstance].validationDelegateQueue =dispatch_get_main_queue();
-    [TrustKit sharedInstance].validationDelegateCallback = ^(TSKPinningValidatorResult * _Nonnull result) {
+    [TrustKit sharedInstance].pinningValidatorCallbackQueue =dispatch_get_main_queue();
+    [TrustKit sharedInstance].pinningValidatorCallback = ^(TSKPinningValidatorResult *result, NSString *notedHostname, TKSDomainPinningPolicy *policy) {
         NSLog(@"Received pinning validation notification:\n\tDuration: %0.4f\n\tDecision: %ld\n\tResult: %ld\n\tHostname: %@",
               result.validationDuration,
               (long)result.finalTrustDecision,
-              (long)result.validationResult,
+              (long)result.evaluationResult,
               result.serverHostname);
     };
     


### PR DESCRIPTION
compiled with -DDEBUG, no longer create unneeded format strings.