### PR TITLE
Fix umbrella dependency error by exposing PublicKeyAlgorithm in Trust…

### DIFF
--- a/TrustKit/TrustKit.h
+++ b/TrustKit/TrustKit.h
@@ -18,6 +18,7 @@
     #import "TSKPinningValidatorCallback.h"
     #import "TSKPinningValidator.h"
     #import "TSKTrustDecision.h"
+    #import "TSKPublicKeyAlgorithm.h"
 #endif /* _TRUSTKIT_ */
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
I have issue with CI flow using Carthage to include TrustKit framework.

While compiling for the first time umbrella header for module 'TrustKit' error happens (if using Carthage dependancy manager):
`Umbrella header for module 'TrustKit' does not include header 'TSKPublicKeyAlgorithm.h'`

 This fix will include missing dependancy.