### PR TITLE
Remove need for python script

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,9 +42,16 @@ To generate such values, a Python helper script is available within the project'
 repository; it can be used to generate the pin configuration from a PEM or DER 
 certificate:
 
-    $ python get_pin_from_certificate.py ca.pem
-    $ python get_pin_from_certificate.py --type DER ca.der
+    $ openssl s_client -servername www.example.com -connect www.example.com:443 | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
+   
+If the command above fails it might be because your openssl version is outdated. Here's one way to install a new one:
 
+    $ brew install openssl
+    $ brew info openssl | grep "echo 'export PATH=.*"
+    
+That last command gave some output. If you run that command you will make openssl available in terminal on a user level. 
+    
+    $ echo 'export PATH="/usr/local/opt/openssl/bin:$PATH"' >> ~/.zshrc
 
 ## Deploying TrustKit
 


### PR DESCRIPTION
In my build script (fastlane / ruby) I was checking that I used the correct public key. I was able to replace this code
```ruby
Helper.backticks "#{openssl_path} s_client -showcerts -connect #{get_env("BAX_SERVER")}:443 </dev/null 2>/dev/null | #{openssl_path} x509 -outform PEM >\"#{cert_path}\""
Helper.backticks "curl -s -o #{script_path} https://raw.githubusercontent.com/datatheorem/TrustKit/master/get_pin_from_certificate.py"
output = Helper.backticks "python #{script_path} #{cert_path} | grep 'kTSKPublicKeyHashes'"
retreived_key = output.sub(/^.+@\[@\"/, '').sub(/\"\].+$/, '').strip
```

With this code
```ruby
output = Helper.backticks "#{openssl_path} s_client -servername #{server} -connect #{server}:443 </dev/null 2>/dev/null | #{openssl_path} x509 -pubkey -noout | #{openssl_path} pkey -pubin -outform der | #{openssl_path} dgst -sha256 -binary | #{openssl_path} enc -base64"
retreived_key = output.lines.last.strip
```

Which is a bit cleaner IMO. 