### PR TITLE
Setting the Expiration Date time zone to UTC

### DIFF
--- a/TrustKit/parse_configuration.m
+++ b/TrustKit/parse_configuration.m
@@ -163,9 +163,10 @@ NSDictionary *parseTrustKitConfiguration(NSDictionary *trustKitArguments)
         NSString *expirationDateStr = domainPinningPolicy[kTSKExpirationDate];
         if (expirationDateStr != nil)
         {
-            // Convert the string in the yyyy-MM-dd format into an actual date
+            // Convert the string in the yyyy-MM-dd format into an actual date in UTC
             NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-            [dateFormat setDateFormat:@"yyyy-MM-dd"];
+            dateFormat.dateFormat = @"yyyy-MM-dd";
+            dateFormat.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
             NSDate *expirationDate = [dateFormat dateFromString:expirationDateStr];
             domainFinalConfiguration[kTSKExpirationDate] = expirationDate;
         }

--- a/TrustKitTests/TSKPinConfigurationTests.m
+++ b/TrustKitTests/TSKPinConfigurationTests.m
@@ -159,7 +159,8 @@
     
     // Validate the content of the config
     NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-    [dateFormat setDateFormat:@"yyyy-MM-dd"];
+    dateFormat.dateFormat = @"yyyy-MM-dd";
+    dateFormat.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     NSDate *expirationDate = [dateFormat dateFromString:expirationDateStr];
     
     NSDictionary *serverConfig = trustKitConfig[kTSKPinnedDomains][serverConfigKey];

--- a/TrustKitTests/TSKReporterTests.m
+++ b/TrustKitTests/TSKReporterTests.m
@@ -110,7 +110,8 @@ static NSString * const kTSKDefaultReportUri = @"https://overmind.datatheorem.co
     
     
     NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-    [dateFormat setDateFormat:@"yyyy-MM-dd"];
+    dateFormat.dateFormat = @"yyyy-MM-dd";
+    dateFormat.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     NSDate *expirationDate = [dateFormat dateFromString:expirationDateStr];
     
     TSKPinningValidatorResult *res;


### PR DESCRIPTION
Specifying a yyyy-MM-dd string as an expiration date is ambiguous depending on the current time zone of the device. Setting the time zone of the NSDateFormatter to UTC will result in consistent expiration calculations independent of the device's local time zone.