### PR TITLE
Adds support for reporting from app extensions

### DIFF
--- a/TrustKit/Reporting/TSKBackgroundReporter.h
+++ b/TrustKit/Reporting/TSKBackgroundReporter.h
@@ -26,10 +26,14 @@
  Initializes a background reporter.
  
  @param shouldRateLimitReports Prevent identical pin failure reports from being sent more than once per day.
+ @param sharedContainerIdentifier The container identifier for an app extension. This must be set in order
+    for reports to be sent from an app extension. See
+    https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1409450-sharedcontaineridentifier
  @exception NSException Thrown when the App does not have a bundle ID, meaning we're running in unit tests where the background transfer service can't be used.
  
  */
-- (nonnull instancetype)initAndRateLimitReports:(BOOL)shouldRateLimitReports;
+- (nonnull instancetype)initAndRateLimitReports:(BOOL)shouldRateLimitReports
+                      sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;
 
 ///----------------------
 /// @name Sending Reports
@@ -38,16 +42,16 @@
 /**
  Send a pin validation failure report; each argument is described section 3. of RFC 7469.
  */
-- (void) pinValidationFailedForHostname:(nonnull NSString *) serverHostname
-                                   port:(nullable NSNumber *) serverPort
-                                  certificateChain:(nonnull NSArray *) certificateChain
-                          notedHostname:(nonnull NSString *) notedHostname
-                             reportURIs:(nonnull NSArray<NSURL *> *) reportURIs
-                      includeSubdomains:(BOOL) includeSubdomains
-                         enforcePinning:(BOOL) enforcePinning
-                              knownPins:(nonnull NSSet<NSData *> *) knownPins
-                       validationResult:(TSKTrustEvaluationResult) validationResult
-                         expirationDate:(nullable NSDate *)knownPinsExpirationDate;
+- (void)pinValidationFailedForHostname:(nonnull NSString *)serverHostname
+                                  port:(nullable NSNumber *)serverPort
+                      certificateChain:(nonnull NSArray *)certificateChain
+                         notedHostname:(nonnull NSString *)notedHostname
+                            reportURIs:(nonnull NSArray<NSURL *> *)reportURIs
+                     includeSubdomains:(BOOL)includeSubdomains
+                        enforcePinning:(BOOL)enforcePinning
+                             knownPins:(nonnull NSSet<NSData *> *)knownPins
+                      validationResult:(TSKTrustEvaluationResult)validationResult
+                        expirationDate:(nullable NSDate *)knownPinsExpirationDate;
 
 - (void)URLSession:(nonnull NSURLSession *)session task:(nonnull NSURLSessionTask *)task didCompleteWithError:(nullable NSError *)error;
 

--- a/TrustKit/Reporting/TSKBackgroundReporter.m
+++ b/TrustKit/Reporting/TSKBackgroundReporter.m
@@ -38,7 +38,8 @@ static NSString * const kTSKBackgroundSessionIdentifierFormat = @"%@.TSKBackgrou
 
 #pragma mark Public methods
 
-- (nonnull instancetype)initAndRateLimitReports:(BOOL)shouldRateLimitReports;
+- (nonnull instancetype)initAndRateLimitReports:(BOOL)shouldRateLimitReports
+                      sharedContainerIdentifier:(NSString *)sharedContainerIdentifier
 {
     self = [super init];
     if (self)
@@ -105,6 +106,7 @@ static NSString * const kTSKBackgroundSessionIdentifierFormat = @"%@.TSKBackgrou
             
             NSURLSessionConfiguration *backgroundConfiguration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:backgroundSessionId];
             backgroundConfiguration.discretionary = YES;
+            backgroundConfiguration.sharedContainerIdentifier = sharedContainerIdentifier;
             
 #if TARGET_OS_IPHONE
             // iOS-only settings

--- a/TrustKit/TrustKit.h
+++ b/TrustKit/TrustKit.h
@@ -120,7 +120,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Usage in Singleton Mode
 
 /**
- Initialize the global TrustKit singleton with the supplied pinning policy.
+ See `+initSharedInstanceWithConfiguration:sharedContainerIdentifier:`
  
  @param trustKitConfig A dictionary containing various keys for configuring the SSL pinning policy.
  @exception NSException Thrown when the supplied configuration is invalid or TrustKit has
@@ -129,6 +129,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)initSharedInstanceWithConfiguration:(NSDictionary<TSKGlobalConfigurationKey, id> *)trustKitConfig;
 
+/**
+ Initialize the global TrustKit singleton with the supplied pinning policy.
+ 
+ @param trustKitConfig A dictionary containing various keys for configuring the SSL pinning policy.
+ @param sharedContainerIdentifier The container identifier for an app extension. This must be set in order
+ for reports to be sent from an app extension. See
+ https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1409450-sharedcontaineridentifier
+ @exception NSException Thrown when the supplied configuration is invalid or TrustKit has
+ already been initialized.
+ 
+ */
++ (void)initSharedInstanceWithConfiguration:(NSDictionary<TSKGlobalConfigurationKey, id> *)trustKitConfig
+                  sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;
 
 /**
  Retrieve the global TrustKit singleton instance. Raises an exception if `+initSharedInstanceWithConfiguration:`
@@ -169,17 +182,27 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Usage in Multi-Instance Mode
 
 /**
- Initialize a local TrustKit instance with the supplied SSL pinning policy configuration.
- 
- This method is useful in scenarios where the TrustKit singleton cannot be used, for example within
- larger Apps that have split some of their functionality into multiple framework/SDK. Each 
- framework can initialize its own instance of TrustKit and use it for pinning validation independently
- of the App's other components.
+ See `-initWithConfiguration:sharedContainerIdentifier:`
  
  @param trustKitConfig A dictionary containing various keys for configuring the SSL pinning policy.
  */
 - (instancetype)initWithConfiguration:(NSDictionary<TSKGlobalConfigurationKey, id> *)trustKitConfig;
 
+/**
+ Initialize a local TrustKit instance with the supplied SSL pinning policy configuration.
+ 
+ This method is useful in scenarios where the TrustKit singleton cannot be used, for example within
+ larger Apps that have split some of their functionality into multiple framework/SDK. Each
+ framework can initialize its own instance of TrustKit and use it for pinning validation independently
+ of the App's other components.
+ 
+ @param trustKitConfig A dictionary containing various keys for configuring the SSL pinning policy.
+ @param sharedContainerIdentifier The container identifier for an app extension. This must be set in order
+    for reports to be sent from an app extension. See
+    https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1409450-sharedcontaineridentifier
+ */
+- (instancetype)initWithConfiguration:(NSDictionary<TSKGlobalConfigurationKey, id> *)trustKitConfig
+            sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;
 
 
 #pragma mark Other Settings

--- a/TrustKitTests/TSKReporterTests.m
+++ b/TrustKitTests/TSKReporterTests.m
@@ -186,7 +186,8 @@ static NSString * const kTSKDefaultReportUri = @"https://overmind.datatheorem.co
 - (void)testReporter
 {
     // Just try a simple valid case to see if we can post this to the default report URL
-    TSKBackgroundReporter *reporter = [[TSKBackgroundReporter alloc] initAndRateLimitReports:NO];
+    TSKBackgroundReporter *reporter = [[TSKBackgroundReporter alloc] initAndRateLimitReports:NO
+                                                                   sharedContainerIdentifier:nil];
     [reporter pinValidationFailedForHostname:@"mail.example.com"
                                         port:[NSNumber numberWithInt:443]
                             certificateChain:_testCertificateChain
@@ -208,7 +209,8 @@ static NSString * const kTSKDefaultReportUri = @"https://overmind.datatheorem.co
 - (void)testReporterNilExpirationDate
 {
     // Just try a simple valid case to see if we can post this to the default report URL
-    TSKBackgroundReporter *reporter = [[TSKBackgroundReporter alloc] initAndRateLimitReports:NO];
+    TSKBackgroundReporter *reporter = [[TSKBackgroundReporter alloc] initAndRateLimitReports:NO
+                                                                   sharedContainerIdentifier:nil];
     [reporter pinValidationFailedForHostname:@"mail.example.com"
                                         port:[NSNumber numberWithInt:443]
                             certificateChain:_testCertificateChain


### PR DESCRIPTION
Currently reporting of certificate errors will fail in certain app extensions with Error Domain=NSURLErrorDomain Code=-995 (`NSURLErrorBackgroundSessionRequiresSharedContainer`).

This PR allows users to pass a `sharedContainerIdentifier` into the initialization functions for an app group that the extension belongs to. This way, certificate errors from extensions such as keyboard, iMessage extension, etc. can still get uploaded.

Verified that this works in an iOS Keyboard.