### PR TITLE
Fix build errors on iOS 12

### DIFF
--- a/TrustKit/Pinning/TSKSPKIHashCache.m
+++ b/TrustKit/Pinning/TSKSPKIHashCache.m
@@ -301,7 +301,8 @@ static const NSString *kTSKKeychainPublicKeyTag = @"TSKKeychainPublicKeyTag"; //
     SecTrustCreateWithCertificates(certificate, policy, &trust);
     
     // Get a public key reference for the certificate from the trust
-    SecTrustEvaluate(trust, NULL);
+    SecTrustResultType result;
+    SecTrustEvaluate(trust, &result);
     SecKeyRef publicKey = SecTrustCopyPublicKey(trust);
     CFRelease(policy);
     CFRelease(trust);
@@ -331,7 +332,8 @@ static const NSString *kTSKKeychainPublicKeyTag = @"TSKKeychainPublicKeyTag"; //
     
     // Get a public key reference from the certificate
     SecTrustCreateWithCertificates(certificate, policy, &tempTrust);
-    SecTrustEvaluate(tempTrust, NULL);
+    SecTrustResultType result;
+    SecTrustEvaluate(tempTrust, &result);
     publicKey = SecTrustCopyPublicKey(tempTrust);
     CFRelease(policy);
     CFRelease(tempTrust);


### PR DESCRIPTION
`SecTrustEvaluate` doesn't accept `NULL` for it's `result` argument anymore.