### PR TITLE
Fix 1 bug, and several static analysis warnings

### DIFF
--- a/TrustKit/Dependencies/domain_registry/private/trie_search.c
+++ b/TrustKit/Dependencies/domain_registry/private/trie_search.c
@@ -277,6 +277,7 @@ const char* GetHostnamePart(size_t offset) {
 }
 
 int HasLeafChildren(const struct TrieNode* node) {
+  if (node == NULL) { return 0; }
   if (node->first_child_offset < g_leaf_node_table_offset) return 0;
   return 1;
 }

--- a/TrustKit/parse_configuration.m
+++ b/TrustKit/parse_configuration.m
@@ -83,7 +83,7 @@ NSDictionary *parseTrustKitConfiguration(NSDictionary *trustKitArguments)
         
         // Always start with the optional excludeSubDomain setting; if it set, no other TSKDomainConfigurationKey can be set for this domain
         NSNumber *shouldExcludeSubdomain = domainPinningPolicy[kTSKExcludeSubdomainFromParentPolicy];
-        if (shouldExcludeSubdomain)
+        if (shouldExcludeSubdomain != nil && [shouldExcludeSubdomain boolValue])
         {
             // Confirm that no other TSKDomainConfigurationKeys were set for this domain
             if ([[domainPinningPolicy allKeys] count] > 1)
@@ -143,7 +143,7 @@ NSDictionary *parseTrustKitConfiguration(NSDictionary *trustKitArguments)
         
         // Extract the optional enforcePinning setting
         NSNumber *shouldEnforcePinning = domainPinningPolicy[kTSKEnforcePinning];
-        if (shouldEnforcePinning)
+        if (shouldEnforcePinning != nil)
         {
             domainFinalConfiguration[kTSKEnforcePinning] = shouldEnforcePinning;
         }
@@ -156,7 +156,7 @@ NSDictionary *parseTrustKitConfiguration(NSDictionary *trustKitArguments)
         
         // Extract the optional disableDefaultReportUri setting
         NSNumber *shouldDisableDefaultReportUri = domainPinningPolicy[kTSKDisableDefaultReportUri];
-        if (shouldDisableDefaultReportUri)
+        if (shouldDisableDefaultReportUri != nil)
         {
             domainFinalConfiguration[kTSKDisableDefaultReportUri] = shouldDisableDefaultReportUri;
         }

--- a/TrustKitTests/TSKPinConfigurationTests.m
+++ b/TrustKitTests/TSKPinConfigurationTests.m
@@ -66,6 +66,28 @@
     XCTAssertEqualObjects(serverConfigKey, @"unsecured.good.com", @"Did not receive a configuration for pinned subdomain");
 }
 
+- (void)testExplicitNotDisablePinningForSubdomainAdditionalDomainKeys
+{
+    NSDictionary *trustKitConfig;
+    trustKitConfig = parseTrustKitConfiguration(@{kTSKPinnedDomains : @{
+                                                          @"good.com" : @{
+                                                                  kTSKPublicKeyHashes : @[@"TQEtdMbmwFgYUifM4LDF+xgEtd0z69mPGmkp014d6ZY=",
+                                                                                          @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                                                                                          ],
+                                                                  kTSKIncludeSubdomains: @YES},
+                                                          @"unsecured.good.com": @{
+                                                                  // When using this option, TrustKit should allow/require a policy for the subdomain
+                                                                  kTSKExcludeSubdomainFromParentPolicy: @NO,
+                                                                  kTSKPublicKeyHashes : @[@"TQEtdMbmwFgYUifM4LDF+xgEtd0z69mPGmkp014d6ZY=",
+                                                                                          @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+                                                                                          ],
+                                                                  }
+                                                          }
+                                                  });
+
+    NSString *serverConfigKey = getPinningConfigurationKeyForDomain(@"unsecured.good.com", trustKitConfig[kTSKPinnedDomains]);
+    XCTAssertEqualObjects(serverConfigKey, @"unsecured.good.com", @"Did not receive a configuration for pinned subdomain");
+}
 
 - (void)testDisablePinningForSubdomainWithoutParentAndNoPublicKey
 {
@@ -104,7 +126,6 @@
                                                  }),
                     @"Configuration with kTSKExcludeSubdomainFromParentPolicy must reject additional domain keys");
 }
-
 
 - (void)testNokTSKSwizzleNetworkDelegates
 {


### PR DESCRIPTION
If `shouldExcludeSubdomain` is explicitly set to NO, it was treated the same as YES. I also added a new unit test that exposes & validates the bug which this PR fixes.

The other changes are trivial static analysis findings in Xcode 10.