### PR TITLE
Fix overlapping pinsets

### DIFF
--- a/TrustKit/configuration_utils.m
+++ b/TrustKit/configuration_utils.m
@@ -15,20 +15,20 @@
 #import "TSKLog.h"
 
 
-static BOOL isSubdomain(NSString *domain, NSString *subdomain)
+static NSUInteger isSubdomain(NSString *domain, NSString *subdomain)
 {
     // Ensure that the TLDs are the same; this can get tricky with TLDs like .co.uk so we take a cautious approach
     size_t domainRegistryLength = GetRegistryLength([domain UTF8String]);
     size_t subdomainRegistryLength = GetRegistryLength([subdomain UTF8String]);
     if (subdomainRegistryLength != domainRegistryLength)
     {
-        return NO;
+        return 0;
     }
     NSString *domainTld = [domain substringFromIndex: [domain length] - domainRegistryLength];
     NSString *subdomainTld = [subdomain substringFromIndex: [subdomain length] - subdomainRegistryLength];
     if (![domainTld isEqualToString:subdomainTld])
     {
-        return NO;
+        return 0;
     }
     
     // Retrieve the main domain without the TLD but append a . at the beginning
@@ -43,9 +43,9 @@ static BOOL isSubdomain(NSString *domain, NSString *subdomain)
     if ([[subComponents lastObject] isEqualToString:@""])
     {
         // This is a subdomain
-        return YES;
+        return [domainLabel length];
     }
-    return NO;
+    return 0;
 }
 
 NSString * _Nullable getPinningConfigurationKeyForDomain(NSString * _Nonnull hostname , NSDictionary<NSString *, TKSDomainPinningPolicy *> * _Nonnull domainPinningPolicies)
@@ -53,6 +53,8 @@ NSString * _Nullable getPinningConfigurationKeyForDomain(NSString * _Nonnull hos
     NSString *notedHostname = nil;
     if (domainPinningPolicies[hostname] == nil)
     {
+        NSUInteger bestMatch = 0;
+
         // No pins explicitly configured for this domain
         // Look for an includeSubdomain pin that applies
         for (NSString *pinnedServerName in domainPinningPolicies)
@@ -62,12 +64,17 @@ NSString * _Nullable getPinningConfigurationKeyForDomain(NSString * _Nonnull hos
             {
                 // Is the server a subdomain of this pinned server?
                 TSKLog(@"Checking includeSubdomains configuration for %@", pinnedServerName);
-                if (isSubdomain(pinnedServerName, hostname))
+                NSUInteger currentMatch = isSubdomain(pinnedServerName, hostname);
+                if (currentMatch > 0 && currentMatch > bestMatch)
                 {
                     // Yes; let's use the parent domain's pinning configuration
-                    TSKLog(@"Applying includeSubdomains configuration from %@ to %@", pinnedServerName, hostname);
+                    TSKLog(@"Applying includeSubdomains configuration from %@ to %@ (new best match of %d chars)", pinnedServerName, hostname, currentMatch);
+                    bestMatch = currentMatch;
                     notedHostname = pinnedServerName;
-                    break;
+                }
+                else if (currentMatch > 0)
+                {
+                    TSKLog(@"Not applying includeSubdomains configuration from %@ to %@ (current match of %d chars does not exceed best match)", pinnedServerName, hostname, currentMatch);
                 }
             }
         }

--- a/TrustKitTests/TSKEndToEndNSURLSessionTests.m
+++ b/TrustKitTests/TSKEndToEndNSURLSessionTests.m
@@ -196,7 +196,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge * _Nonnull)challenge
           @{
               @"www.datatheorem.com" : @{
                       kTSKEnforcePinning : @YES,
-                      kTSKPublicKeyHashes : @[@"58qRu/uxh4gFezqAcERupSkRYBlBAvfcw7mEjGPLnNU=", // CA key
+                      kTSKPublicKeyHashes : @[@"YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=", // CA key for Let's Encrypt Authority X3 (cert valid until 17 Mar 2021)
                                               @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // Fake key
                                               ]}}};
     

--- a/TrustKitTests/TSKPinConfigurationTests.m
+++ b/TrustKitTests/TSKPinConfigurationTests.m
@@ -326,6 +326,28 @@
 }
 
 
+- (void)testIncludeSubdomainsEnabledAndOverlap
+{
+    NSDictionary *trustKitConfig;
+    trustKitConfig = parseTrustKitConfiguration(@{kTSKPinnedDomains :
+                                                      @{@"good.com" : @{
+                                                                kTSKIncludeSubdomains : @YES,
+                                                                kTSKPublicKeyHashes : @[@"TQEtdMbmwFgYUifM4LDF+xgEtd0z69mPGmkp014d6ZY=",
+                                                                                        @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // Fake key
+                                                                                        ]},
+                                                        @"www.good.com": @{
+                                                                kTSKIncludeSubdomains : @YES,
+                                                                kTSKPublicKeyHashes : @[@"iQMk4onrJJz/nwW1wCUR0Ycsh3omhbM+PqMEwNof/K0=",
+                                                                                        @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // Fake key
+                                                                                        ]}}});
+
+    // Ensure the configuration of www.good.com with a longer match takes precedence over the more general config for good.com
+    NSString *serverConfigKey = getPinningConfigurationKeyForDomain(@"foo.www.good.com", trustKitConfig[kTSKPinnedDomains]);
+    XCTAssertEqualObjects(serverConfigKey, @"www.good.com",
+                          @"Overlapping configurations with IncludeSubdomains did not use the most specific (longest) matching configuration");
+}
+
+
 - (void)testNoPinnedDomains
 {
     XCTAssertThrows(parseTrustKitConfiguration(@{kTSKSwizzleNetworkDelegates : @YES}),


### PR DESCRIPTION
I noticed that TrustKit behaves unpredictably in a particular corner case--
If there are two overlapping pinsets that include subdomains (say, "foo.com" and "bar.foo.com"), and a host matches both pinsets (say, "baz.bar.foo.com"), the selected pinset cannot be predicted. It's simply determined by which of those two keys shows up first while TrustKit is iterating over its dictionary of domains.

The best example of industry best practice I could find was from Google.
As far as I know, Android is the only platform that provides cert pinning functionality out-of-the-box.
And, TrustKit-Android relies on the base Android pinning implementation.

Google has chosen to handle this corner case by choosing the "most specific (longest) matching domain rule".
See the following links for references:

* https://developer.android.com/training/articles/security-config#domain-config
* http://androidxref.com/9.0.0_r3/xref/frameworks/base/core/java/android/security/net/config/ApplicationConfig.java#58

This is the behavior I had originally expected TrustKit to adhere to.

I modified the selection code to use this approach, and wrote a unit test to validate it.