### PR TITLE
Adding DEFINES_MODULE Flags

### DIFF
--- a/TrustKit.podspec
+++ b/TrustKit.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '3.0'
 
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.source_files = ['TrustKit', 'TrustKit/**/*.{h,m,c}']
   s.public_header_files = [
     'TrustKit/TrustKit.h',


### PR DESCRIPTION
Currently TrustKit can't be packaged in a static Swift Library without modules.
"Pod package" fail if TrustKit is in other podspec dependency.
Addind this line will generate module maps for swift dependencies.