### PR TITLE
Save & load the SPKI disk cache using secure coding.

### DIFF
--- a/TrustKit/Pinning/TSKSPKIHashCache.m
+++ b/TrustKit/Pinning/TSKSPKIHashCache.m
@@ -194,7 +194,13 @@ static unsigned int getAsn1HeaderSize(NSString *publicKeyType, NSNumber *publicK
     
     // Update the cache on the filesystem
     if (self.spkiCacheFilename.length > 0) {
-        NSData *serializedSpkiCache = [NSKeyedArchiver archivedDataWithRootObject:_spkiCache];
+        NSData *serializedSpkiCache = nil;
+        if (@available(iOS 11.0, *)) { // prefer NSSecureCoding API when available
+            serializedSpkiCache = [NSKeyedArchiver archivedDataWithRootObject:_spkiCache requiringSecureCoding:YES error:nil];
+        } else {
+            serializedSpkiCache = [NSKeyedArchiver archivedDataWithRootObject:_spkiCache];
+        }
+
         if ([serializedSpkiCache writeToURL:[self SPKICachePath] atomically:YES] == NO)
         {
             NSAssert(false, @"Failed to write cache");
@@ -210,7 +216,11 @@ static unsigned int getAsn1HeaderSize(NSString *publicKeyType, NSNumber *publicK
     NSMutableDictionary *spkiCache = nil;
     NSData *serializedSpkiCache = [NSData dataWithContentsOfURL:[self SPKICachePath]];
     if (serializedSpkiCache) {
-        spkiCache = [NSKeyedUnarchiver unarchiveObjectWithData:serializedSpkiCache];
+        if (@available(iOS 11.0, *)) { // prefer NSSecureCoding API when available
+            spkiCache = [NSKeyedUnarchiver unarchivedObjectOfClass:[SPKICacheDictionnary class] fromData:serializedSpkiCache error:nil];
+        } else {
+            spkiCache = [NSKeyedUnarchiver unarchiveObjectWithData:serializedSpkiCache];
+        }
     }
     return spkiCache;
 }


### PR DESCRIPTION
## Synopsis

NSSecureCoding encodes data about the original object that was serialized. During the de-serialization process, the secure coding APIs enforce that the created object is of the expected type. This is designed to prevent a substitution attacks in which a serialized file is modified in a way that allows the attacker to run arbitrary code with the privileges – and in the context – of the app.

## Attack Details

This code was flagged by automated static security scanners at Yahoo. The vulnerability details are here: https://cwe.mitre.org/data/definitions/502.html 

The scanner message:
```
Unsecure_Deserialization issue exists @ TrustKit/TrustKit/Pinning/TSKSPKIHashCache.m

Data from an untrusted input element dataWithContentsOfURL: at line 208 of TrustKit\TrustKit\Pinning\TSKSPKIHashCache.m is used to deserialize an object unarchiveObjectWithData: at line 208 of TrustKit\TrustKit\Pinning\TSKSPKIHashCache.m. While the class of unarchiveObjectWithData:object does NOT conform to NSSecureCoding protocol.
```

## Proposed Fix

We figure this is easily solved by switching to the NSSecureCoding API introduced in iOS 11. The persisted data is of type `NSMutableDictionary<NSData *, NSData *>`, which already supports `NSSecureCoding` (both the object and the generic types).

## Impact

Since the data is not currently _persisted_ using a secure coding API, the de-serialization might fail. Specifically, `-loadSPKICacheFromFileSystem` may not succeed after the upgrade. This situation is identical to the "first launch" scenario. Upon initialization a new cache will be saved using the secure coding APIs and subsequent launches will operate as they currently do.