### PR TITLE
Integer overflow check in memory allocation

### DIFF
--- a/TrustKit/Dependencies/RSSwizzle/RSSwizzle.m
+++ b/TrustKit/Dependencies/RSSwizzle/RSSwizzle.m
@@ -83,7 +83,8 @@ static BOOL blockIsCompatibleWithMethodType(id block, const char *methodType){
         char *quotePtr = strchr(blockType+2, '"');
         if (NULL != quotePtr) {
             ++quotePtr;
-            char filteredType[strlen(quotePtr) + 2];
+            NSCAssert(strlen(quotePtr) + 2 < 1024, @"Method signatures over 1KB are not supported");
+            char filteredType[1024];
             memset(filteredType, 0, sizeof(filteredType));
             *filteredType = '@';
             strncpy(filteredType + 1, quotePtr, sizeof(filteredType) - 2);

--- a/TrustKit/Dependencies/RSSwizzle/RSSwizzle.m
+++ b/TrustKit/Dependencies/RSSwizzle/RSSwizzle.m
@@ -83,8 +83,12 @@ static BOOL blockIsCompatibleWithMethodType(id block, const char *methodType){
         char *quotePtr = strchr(blockType+2, '"');
         if (NULL != quotePtr) {
             ++quotePtr;
-            NSCAssert(strlen(quotePtr) + 2 < 1024, @"Method signatures over 1KB are not supported");
-            char filteredType[1024];
+            size_t filterTypeLen = strlen(quotePtr) + 2;
+            if (strlen(quotePtr) > filterTypeLen) { // integer overflow check
+                NSCAssert(false, @"Method signature is too long to swizzle");
+                return NO;
+            }
+            char filteredType[filterTypeLen];
             memset(filteredType, 0, sizeof(filteredType));
             *filteredType = '@';
             strncpy(filteredType + 1, quotePtr, sizeof(filteredType) - 2);


### PR DESCRIPTION
## Synopsis

The copy of RSSwizzle embedded in TrustKit uses an unchecked outside value to allocate memory. The PR adds integer overflow protection to the memory allocation size.

## Attack Details

This code was flagged by automated static security scanners at Yahoo. The vulnerability details are https://cwe.mitre.org/data/definitions/190.html

The scanner message:
```
Signed_Memory_Arithmetic issue exists @ TrustKit/TrustKit/Dependencies/RSSwizzle/RSSwizzle.m
Signed integer strlen at line 73 of TrustKit\TrustKit\Dependencies\RSSwizzle\RSSwizzle.m specifies size of memory to allocate.
```

## Proposed Fix

Added a simple integer overflow check to the code: `if (strlen(x) > strlen(..)+2) {...}`. When this case is true, the Swizzling is aborted.

## Impact

There is no realistic failure path that doesn't impact the library. In the event of integer overflow in the objective-c type specifier, I added `return NO`, effectively declining to swizzle the method. The alternative is to allow the integer overflow, which will almost certainly crash the containing program. I would say that the impact of having this fix is "less severe" than not having it.