### PR TITLE
Updated Swift Package Manager product to be dynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     products: [
         .library(
             name: "TrustKit",
+            type: .dynamic,
             targets: ["TrustKit"]
         ),
     ],


### PR DESCRIPTION
Switched the products from Swift Package Manager to be `dynamic` rather than `static`. 

By default, Swift Package Manager sets this to `static` and can cause linking issues. The specific error I am trying to address is:
> error: Swift package product LIBRARY is linked as a static library by APP and EXTENSION. This will result in duplication of library code.