### PR TITLE
Update pinned certs in unit tests

### DIFF
--- a/TrustKitTests/TSKEndToEndNSURLSessionTests.m
+++ b/TrustKitTests/TSKEndToEndNSURLSessionTests.m
@@ -196,7 +196,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge * _Nonnull)challenge
           @{
               @"www.datatheorem.com" : @{
                       kTSKEnforcePinning : @YES,
-                      kTSKPublicKeyHashes : @[@"YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=", // CA key for Let's Encrypt Authority X3 (cert valid until 17 Mar 2021)
+                      kTSKPublicKeyHashes : @[@"cXjPgKdVe6iojP8s0YQJ3rtmDFHTnYZxcYvmYGFiYME=", // CA key for Google Trust Services (cert valid until 27 Jan 2028)
                                               @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // Fake key
                                               ]}}};
     

--- a/TrustKitTests/TSKEndToEndSwizzlingTests.m
+++ b/TrustKitTests/TSKEndToEndSwizzlingTests.m
@@ -166,7 +166,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge * _Nonnull)challenge
               // Valid pinning configuration
               @"www.cloudflare.com" : @{
                       kTSKEnforcePinning : @YES,
-                      kTSKPublicKeyHashes : @[@"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=", // CA key
+                      kTSKPublicKeyHashes : @[@"FEzVOUp4dF3gI0ZVPRJhFbSJVXR+uQmMH65xhs1glH4=", // CA key
                                               @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // Fake key
                                               ]},
               // Invalid pinning configuration


### PR DESCRIPTION
A few unit tests were failing because the pinned certificates recently expired. This PR updates the pinned certificates