### PR TITLE
Fix crash when cache persisting fails

### DIFF
--- a/TrustKit/Pinning/TSKSPKIHashCache.m
+++ b/TrustKit/Pinning/TSKSPKIHashCache.m
@@ -231,7 +231,6 @@ static unsigned int getAsn1HeaderSize(NSString *publicKeyType, NSNumber *publicK
         NSData *serializedSpkiCache = [NSKeyedArchiver archivedDataWithRootObject:_spkiCache requiringSecureCoding:YES error:nil];
         if ([serializedSpkiCache writeToURL:[self SPKICachePath] atomically:YES] == NO)
         {
-            NSAssert(false, @"Failed to write cache");
             TSKLog(@"Could not persist SPKI cache to the filesystem");
         }
     }


### PR DESCRIPTION
Removed excessive `NSAssert` in order to fix #261