### PR TITLE
Use NS_BLOCK_ASSERTIONS for SwiftPM release builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,8 @@ let package = Package(
             name: "TrustKit",
             dependencies: [],
             path: "TrustKit",            
-            publicHeadersPath: "public"
+            publicHeadersPath: "public",
+            cSettings: [.define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release))]
         ),
     ]
 )


### PR DESCRIPTION
Xcode doesn't automatically set the NS_BLOCK_ASSERTIONS flag for SwiftPM release builds.

Use cSettings to set the flag, so NSAssert doesn't crash release builds and behavior is similar to using Carthage or Cocoapods.

See https://forums.swift.org/t/assertions-in-swift-packages/42692 for more info.

Fix for #261