### PR TITLE
Improve static initializer calls

### DIFF
--- a/TrustKit/TrustKit.m
+++ b/TrustKit/TrustKit.m
@@ -116,7 +116,7 @@ void TSKLog(NSString *format, ...)
 
 #pragma mark Instance Initialization
 
-- (instancetype)initFromPlistConfiguration {
+- (instancetype)initConfigurationFromPlist {
 	// TrustKit just got started in the App
     CFBundleRef appBundle = CFBundleGetMainBundle();
     
@@ -125,8 +125,13 @@ void TSKLog(NSString *format, ...)
     if (trustKitConfigFromInfoPlist)
     {
         TSKLog(@"Configuration supplied via the App's Info.plist");
-        [TrustKit initSharedInstanceWithConfiguration:trustKitConfigFromInfoPlist];
+        return [self initWithConfiguration:trustKitConfigFromInfoPlist
+                 sharedContainerIdentifier:nil];
     }
+		
+    @throw([NSException exceptionWithName:@"Cannot find the plist TrustKit key configuration"
+                                   reason:@"Tried to fill with `TSKConfiguration` as configuration"
+                                 userInfo:nil]);
 }
 
 - (instancetype)initWithConfiguration:(NSDictionary<TSKGlobalConfigurationKey, id> *)trustKitConfig

--- a/TrustKit/TrustKit.m
+++ b/TrustKit/TrustKit.m
@@ -95,17 +95,6 @@ void TSKLog(NSString *format, ...)
                   sharedContainerIdentifier:(NSString *)sharedContainerIdentifier
 {
     TSKLog(@"Configuration passed via explicit call to initSharedInstanceWithConfiguration:");
-
-		// TrustKit just got started in the App
-    CFBundleRef appBundle = CFBundleGetMainBundle();
-    
-    // Retrieve the configuration from the App's Info.plist file
-    NSDictionary *trustKitConfigFromInfoPlist = (__bridge NSDictionary *)CFBundleGetValueForInfoDictionaryKey(appBundle, (__bridge CFStringRef)kTSKConfiguration);
-    if (trustKitConfigFromInfoPlist)
-    {
-        TSKLog(@"Configuration supplied via the App's Info.plist");
-        // [TrustKit initSharedInstanceWithConfiguration:trustKitConfigFromInfoPlist];
-    }
     
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -127,6 +116,18 @@ void TSKLog(NSString *format, ...)
 
 #pragma mark Instance Initialization
 
+- (instancetype)initFromPlistConfiguration {
+	// TrustKit just got started in the App
+    CFBundleRef appBundle = CFBundleGetMainBundle();
+    
+    // Retrieve the configuration from the App's Info.plist file
+    NSDictionary *trustKitConfigFromInfoPlist = (__bridge NSDictionary *)CFBundleGetValueForInfoDictionaryKey(appBundle, (__bridge CFStringRef)kTSKConfiguration);
+    if (trustKitConfigFromInfoPlist)
+    {
+        TSKLog(@"Configuration supplied via the App's Info.plist");
+        [TrustKit initSharedInstanceWithConfiguration:trustKitConfigFromInfoPlist];
+    }
+}
 
 - (instancetype)initWithConfiguration:(NSDictionary<TSKGlobalConfigurationKey, id> *)trustKitConfig
 {
@@ -281,21 +282,3 @@ void TSKLog(NSString *format, ...)
 }
 
 @end
-
-
-#pragma mark TrustKit Implicit Initialization via Library Constructor
-
-
-// __attribute__((constructor)) static void initializeWithInfoPlist(int argc, const char **argv)
-// {
-//     // TrustKit just got started in the App
-//     CFBundleRef appBundle = CFBundleGetMainBundle();
-    
-//     // Retrieve the configuration from the App's Info.plist file
-//     NSDictionary *trustKitConfigFromInfoPlist = (__bridge NSDictionary *)CFBundleGetValueForInfoDictionaryKey(appBundle, (__bridge CFStringRef)kTSKConfiguration);
-//     if (trustKitConfigFromInfoPlist)
-//     {
-//         TSKLog(@"Configuration supplied via the App's Info.plist");
-//         [TrustKit initSharedInstanceWithConfiguration:trustKitConfigFromInfoPlist];
-//     }
-// }

--- a/TrustKit/TrustKit.m
+++ b/TrustKit/TrustKit.m
@@ -95,6 +95,17 @@ void TSKLog(NSString *format, ...)
                   sharedContainerIdentifier:(NSString *)sharedContainerIdentifier
 {
     TSKLog(@"Configuration passed via explicit call to initSharedInstanceWithConfiguration:");
+
+		// TrustKit just got started in the App
+    CFBundleRef appBundle = CFBundleGetMainBundle();
+    
+    // Retrieve the configuration from the App's Info.plist file
+    NSDictionary *trustKitConfigFromInfoPlist = (__bridge NSDictionary *)CFBundleGetValueForInfoDictionaryKey(appBundle, (__bridge CFStringRef)kTSKConfiguration);
+    if (trustKitConfigFromInfoPlist)
+    {
+        TSKLog(@"Configuration supplied via the App's Info.plist");
+        // [TrustKit initSharedInstanceWithConfiguration:trustKitConfigFromInfoPlist];
+    }
     
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -275,16 +286,16 @@ void TSKLog(NSString *format, ...)
 #pragma mark TrustKit Implicit Initialization via Library Constructor
 
 
-__attribute__((constructor)) static void initializeWithInfoPlist(int argc, const char **argv)
-{
-    // TrustKit just got started in the App
-    CFBundleRef appBundle = CFBundleGetMainBundle();
+// __attribute__((constructor)) static void initializeWithInfoPlist(int argc, const char **argv)
+// {
+//     // TrustKit just got started in the App
+//     CFBundleRef appBundle = CFBundleGetMainBundle();
     
-    // Retrieve the configuration from the App's Info.plist file
-    NSDictionary *trustKitConfigFromInfoPlist = (__bridge NSDictionary *)CFBundleGetValueForInfoDictionaryKey(appBundle, (__bridge CFStringRef)kTSKConfiguration);
-    if (trustKitConfigFromInfoPlist)
-    {
-        TSKLog(@"Configuration supplied via the App's Info.plist");
-        [TrustKit initSharedInstanceWithConfiguration:trustKitConfigFromInfoPlist];
-    }
-}
+//     // Retrieve the configuration from the App's Info.plist file
+//     NSDictionary *trustKitConfigFromInfoPlist = (__bridge NSDictionary *)CFBundleGetValueForInfoDictionaryKey(appBundle, (__bridge CFStringRef)kTSKConfiguration);
+//     if (trustKitConfigFromInfoPlist)
+//     {
+//         TSKLog(@"Configuration supplied via the App's Info.plist");
+//         [TrustKit initSharedInstanceWithConfiguration:trustKitConfigFromInfoPlist];
+//     }
+// }

--- a/TrustKit/public/TrustKit.h
+++ b/TrustKit/public/TrustKit.h
@@ -183,7 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Initialize a local TrustKit instance with configuration from PList.
  **/
-- (instancetype)initFromPlistConfiguration;
+- (instancetype)initConfigurationFromPlist;
 
 
 /**

--- a/TrustKit/public/TrustKit.h
+++ b/TrustKit/public/TrustKit.h
@@ -181,6 +181,12 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Usage in Multi-Instance Mode
 
 /**
+ * Initialize a local TrustKit instance with configuration from PList.
+ **/
+- (instancetype)initFromPlistConfiguration;
+
+
+/**
  See `-initWithConfiguration:sharedContainerIdentifier:`
  
  @param trustKitConfig A dictionary containing various keys for configuring the SSL pinning policy.


### PR DESCRIPTION
Configuration the project which set up programmatically, but found on startup the unneeded initialize call on a constructor.

Let's make initialize call configuration by PList optional.

<img width="959" alt="151257753-e77d9981-0270-40f8-a82d-a33a63235d6b" src="https://user-images.githubusercontent.com/3015018/151258396-175285c4-364a-41d7-9fc4-fc6632d9a3f3.png">

