### PR TITLE
Enable Nsurlconnections and vendor

### DIFF
--- a/TrustKit/Reporting/TSKBackgroundReporter.m
+++ b/TrustKit/Reporting/TSKBackgroundReporter.m
@@ -11,6 +11,7 @@
 
 #import "TSKBackgroundReporter.h"
 #import "../public/TSKTrustKitConfig.h"
+#import "../configuration_utils.h"
 #import "../TSKLog.h"
 #import "TSKPinFailureReport.h"
 #import "reporting_utils.h"
@@ -87,7 +88,8 @@ static NSString * const kTSKBackgroundSessionIdentifierFormat = @"%@.TSKBackgrou
             _appBundleId = @"N/A";
             _appVendorId = @"unit-tests";
             
-            _backgroundSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+
+            _backgroundSession = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()
                                                                delegate:self
                                                           delegateQueue:nil];
         }
@@ -112,6 +114,10 @@ static NSString * const kTSKBackgroundSessionIdentifierFormat = @"%@.TSKBackgrou
             // iOS-only settings
             // Do not wake up the App after completing the upload
             backgroundConfiguration.sessionSendsLaunchEvents = NO;
+#if !TARGET_OS_TV && !TARGET_OS_WATCH
+            // on iOS (but not tvOS or watchOS), enable multipath
+            backgroundConfiguration.multipathServiceType = NSURLSessionMultipathServiceTypeHandover;
+#endif
 #endif
             
             // We have to use a delegate as background sessions can't use completion handlers

--- a/TrustKit/Reporting/vendor_identifier.m
+++ b/TrustKit/Reporting/vendor_identifier.m
@@ -11,29 +11,7 @@
 
 #import "vendor_identifier.h"
 
-#if TARGET_OS_IPHONE && !TARGET_OS_WATCH
-
-#pragma mark Vendor identifier - iOS, tvOS
-
-// for accessing the IDFV
-#if __has_feature(modules)
-@import UIKit;
-#else
-#import <UIKit/UIKit.h>
-#endif
-
-NSString *identifier_for_vendor(void)
-{
-    return UIDevice.currentDevice.identifierForVendor.UUIDString;
-}
-
-#else
-
-#pragma mark Vendor identifier - macOS, watchOS
-
-
 static NSString * const kTSKVendorIdentifierKey = @"TSKVendorIdentifier";
-
 
 NSString *identifier_for_vendor(void)
 {
@@ -50,6 +28,4 @@ NSString *identifier_for_vendor(void)
     return vendorId;
 }
 
-
-#endif
 

--- a/TrustKit/configuration_utils.h
+++ b/TrustKit/configuration_utils.h
@@ -19,3 +19,7 @@
 
 // Figure out if a specific domain is pinned and retrieve this domain's configuration key; returns nil if no configuration was found
 NSString * _Nullable getPinningConfigurationKeyForDomain(NSString * _Nonnull hostname , NSDictionary<NSString *, TKSDomainPinningPolicy *> * _Nonnull domainPinningPolicies);
+
+// Create an ephemeral NSURLSessionConfiguration, with best practices defaults
+// for the current platform
+NSURLSessionConfiguration * _Nonnull ephemeralNSURLSessionConfiguration(void);

--- a/TrustKit/configuration_utils.m
+++ b/TrustKit/configuration_utils.m
@@ -98,3 +98,11 @@ NSString * _Nullable getPinningConfigurationKeyForDomain(NSString * _Nonnull hos
     }
     return notedHostname;
 }
+
+NSURLSessionConfiguration *ephemeralNSURLSessionConfiguration() {
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+#if TARGET_OS_IPHONE && !TARGET_OS_TV && !TARGET_OS_WATCH
+    configuration.multipathServiceType = NSURLSessionMultipathServiceTypeHandover;
+#endif
+    return configuration;
+}

--- a/TrustKitTests/TSKEndToEndNSURLSessionTests.m
+++ b/TrustKitTests/TSKEndToEndNSURLSessionTests.m
@@ -167,8 +167,9 @@ didReceiveChallenge:(NSURLAuthenticationChallenge * _Nonnull)challenge
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"TestNSURLSessionTaskDelegate"];
     TestNSURLSessionDelegate* delegate = [[TestNSURLSessionDelegate alloc] initWithValidator:trustKit.pinningValidator expectation:expectation];
-    
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+
+
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()
                                                           delegate:delegate
                                                      delegateQueue:nil];
     
@@ -222,7 +223,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge * _Nonnull)challenge
     XCTestExpectation *expectation = [self expectationWithDescription:@"TestNSURLSessionTaskDelegate"];
     TestNSURLSessionDelegate* delegate = [[TestNSURLSessionDelegate alloc] initWithValidator:trustKit.pinningValidator expectation:expectation];
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()
                                                           delegate:delegate
                                                      delegateQueue:nil];
     
@@ -279,7 +280,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge * _Nonnull)challenge
     XCTestExpectation *expectation = [self expectationWithDescription:@"TestNSURLSessionTaskDelegate"];
     TestNSURLSessionDelegate* delegate = [[TestNSURLSessionDelegate alloc] initWithValidator:trustKit.pinningValidator expectation:expectation];
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()
                                                           delegate:delegate
                                                      delegateQueue:nil];
     
@@ -324,7 +325,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge * _Nonnull)challenge
     XCTestExpectation *expectation = [self expectationWithDescription:@"TestNSURLSessionTaskDelegate"];
     TestNSURLSessionDelegate* delegate = [[TestNSURLSessionDelegate alloc] initWithValidator:trustKit.pinningValidator expectation:expectation];
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()
                                                           delegate:delegate
                                                      delegateQueue:nil];
     

--- a/TrustKitTests/TSKEndToEndSwizzlingTests.m
+++ b/TrustKitTests/TSKEndToEndSwizzlingTests.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "../TrustKit/public/TrustKit.h"
+#import "../TrustKit/configuration_utils.h"
 
 
 
@@ -219,7 +220,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge * _Nonnull)challenge
     TestNSURLSessionDelegateSwizzling* delegate = [[TestNSURLSessionDelegateSwizzling alloc] initWithValidator:TrustKit.sharedInstance.pinningValidator
                                                                                                    expectation:expectation];
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()
                                                           delegate:delegate
                                                      delegateQueue:nil];
     

--- a/TrustKitTests/TSKNSURLSessionTests.m
+++ b/TrustKitTests/TSKNSURLSessionTests.m
@@ -11,6 +11,7 @@
 #import "../TrustKit/public/TSKPinningValidator.h"
 #import "../TrustKit/public/TSKPinningValidatorResult.h"
 #import "../TrustKit/Swizzling/TSKNSURLSessionDelegateProxy.h"
+#import "../TrustKit/configuration_utils.h"
 
 #import <OCMock/OCMock.h>
 
@@ -167,7 +168,7 @@
     TSKNSURLSessionDelegateProxy *proxy = [[TSKNSURLSessionDelegateProxy alloc] initWithTrustKit:self.trustKit
                                                                                  sessionDelegate:delegate];
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()];
     NSURLAuthenticationChallenge *challenge = ({
         NSURLProtectionSpace *space = [[NSURLProtectionSpace alloc] initWithHost:@""
                                                                             port:443
@@ -197,7 +198,7 @@
     TSKNSURLSessionDelegateProxy *proxy = [[TSKNSURLSessionDelegateProxy alloc] initWithTrustKit:self.trustKit
                                                                                  sessionDelegate:delegate];
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()];
     NSURLAuthenticationChallenge *challenge = ({
         NSURLProtectionSpace *space = [[NSURLProtectionSpace alloc] initWithHost:@""
                                                                             port:443
@@ -227,7 +228,7 @@
     TSKNSURLSessionDelegateProxy *proxy = [[TSKNSURLSessionDelegateProxy alloc] initWithTrustKit:self.trustKit
                                                                                  sessionDelegate:delegate];
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()];
     NSURLAuthenticationChallenge *challenge = ({
         NSURLProtectionSpace *space = [[NSURLProtectionSpace alloc] initWithHost:@"hostname"
                                                                             port:443
@@ -264,7 +265,7 @@
     TSKNSURLSessionDelegateProxy *proxy = [[TSKNSURLSessionDelegateProxy alloc] initWithTrustKit:self.trustKit
                                                                                  sessionDelegate:delegate];
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()];
     NSURLAuthenticationChallenge *challenge = ({
         NSURLProtectionSpace *space = [[NSURLProtectionSpace alloc] initWithHost:@"hostname"
                                                                             port:443
@@ -303,7 +304,7 @@
     TSKNSURLSessionDelegateProxy *proxy = [[TSKNSURLSessionDelegateProxy alloc] initWithTrustKit:self.trustKit
                                                                                  sessionDelegate:delegate];
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()];
     NSURLAuthenticationChallenge *challenge = ({
         NSURLProtectionSpace *space = [[NSURLProtectionSpace alloc] initWithHost:@"hostname"
                                                                             port:443
@@ -339,7 +340,7 @@
     TSKNSURLSessionDelegateProxy *proxy = [[TSKNSURLSessionDelegateProxy alloc] initWithTrustKit:self.trustKit
                                                                                  sessionDelegate:delegate];
     
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:ephemeralNSURLSessionConfiguration()];
     NSURLAuthenticationChallenge *challenge = ({
         NSURLProtectionSpace *space = [[NSURLProtectionSpace alloc] initWithHost:@"hostname"
                                                                             port:443


### PR DESCRIPTION
update NSURLConnections to use multipathServiceTypein their configs on iOS.

Remove usage of UIDevice.currentDevice.identifierForVendor.UUIDString on iOS and TvOS and use the macOS/watchOS behavior instead, which generates a random UUID and stores it in the user preferences. This is to avoid adding a requirement for dependent apps of declaring usage of the IDFV.