### PR TITLE
Fix for crash reported on iOS 17

### DIFF
--- a/TrustKit/Pinning/pinning_utils.m
+++ b/TrustKit/Pinning/pinning_utils.m
@@ -55,7 +55,11 @@ SecCertificateRef getCertificateAtIndex(SecTrustRef serverTrust, CFIndex index) 
     int osVersionThreshold = 12; // macOS 12+
 #endif
     SecCertificateRef certificate = NULL;
-    void *_Security = dlopen("/System/Library/Frameworks/Security.framework/Security", RTLD_NOW);
+    void *_Security = dlopen("Security.framework/Security", RTLD_NOW);
+    if (_Security == NULL) {
+        _Security = dlopen("/System/Library/Frameworks/Security.framework/Security", RTLD_NOW);
+    }
+
     if (majorVersion >= osVersionThreshold)
     {
         CFArrayRef (*_SecTrustCopyCertificateChain)(SecTrustRef) = dlsym(_Security, "SecTrustCopyCertificateChain");

--- a/TrustKit/Pinning/pinning_utils.m
+++ b/TrustKit/Pinning/pinning_utils.m
@@ -55,7 +55,7 @@ SecCertificateRef getCertificateAtIndex(SecTrustRef serverTrust, CFIndex index) 
     int osVersionThreshold = 12; // macOS 12+
 #endif
     SecCertificateRef certificate = NULL;
-    void *_Security = dlopen("Security.framework/Security", RTLD_NOW);
+    void *_Security = dlopen("/System/Library/Frameworks/Security.framework/Security", RTLD_NOW);
     if (majorVersion >= osVersionThreshold)
     {
         CFArrayRef (*_SecTrustCopyCertificateChain)(SecTrustRef) = dlsym(_Security, "SecTrustCopyCertificateChain");


### PR DESCRIPTION
In iOS 17 beta, the following crash was reported, this PR contains fix for the crash

```
Thread 13 name:   Dispatch queue: NSOperationQueue 0x1063289a0 (QOS: UNSPECIFIED)
Thread 13 Crashed:
0   ???                                         0x0 ???
1   privacy_Example                     0x100911bac verifyPublicKeyPin + 1168
2   privacy_Example                     0x100919250 -[TSKPinningValidator evaluateTrust:forHostname:] + 924
3   privacy_Example                     0x100919808 -[TSKPinningValidator handleChallenge:completionHandler:] + 348
```