### PR TITLE
Add PrivacyInfo.xcprivacy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,8 @@ let package = Package(
         .target(
             name: "TrustKit",
             dependencies: [],
-            path: "TrustKit",            
+            path: "TrustKit",
+            resources: [.process("framework/PrivacyInfo.xcprivacy")],
             publicHeadersPath: "public",
             cSettings: [.define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release))]
         ),

--- a/TrustKit.podspec
+++ b/TrustKit.podspec
@@ -25,4 +25,5 @@ Pod::Spec.new do |s|
   ]
   s.frameworks = ['Foundation', 'Security']
   s.requires_arc = true
+  s.resource_bundles = {'TrustKit' => ['TrustKit/Framework/PrivacyInfo.xcprivacy']}
 end

--- a/TrustKit/Framework/PrivacyInfo.xcprivacy
+++ b/TrustKit/Framework/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/TrustKit/Framework/PrivacyInfo.xcprivacy
+++ b/TrustKit/Framework/PrivacyInfo.xcprivacy
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This PR adds a privacy manfiest (PrivacyInfo.xcprivacy), Apple has not been mentioned [here](https://developer.apple.com/support/third-party-SDK-requirements), but this SDK is using the [User Defaults API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)

However, choosing a reason for NSPrivacyAccessedAPITypeReasons can be somewhat confusing. It would be helpful if you could check if there are any NSPrivacyAccessedAPITypeReasons that you think are more suitable.

resolve #319 