### PR TITLE
Improve SPKI cache thread safety and handle protected data availability

### DIFF
--- a/TrustKitTests/TSKEndToEndNSURLSessionTests.m
+++ b/TrustKitTests/TSKEndToEndNSURLSessionTests.m
@@ -197,7 +197,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge * _Nonnull)challenge
           @{
               @"www.datatheorem.com" : @{
                       kTSKEnforcePinning : @YES,
-                      kTSKPublicKeyHashes : @[@"cXjPgKdVe6iojP8s0YQJ3rtmDFHTnYZxcYvmYGFiYME=", // CA key for Google Trust Services (cert valid until 27 Jan 2028)
+                      kTSKPublicKeyHashes : @[@"hxqRlPTu1bMS/0DITB1SSu0vd4u/8l8TjPgfaAp63Gc=", // CA key for Google Trust Services (cert valid until 27 Jan 2028)
                                               @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // Fake key
                                               ]}}};
     

--- a/TrustKitTests/TSKEndToEndSwizzlingTests.m
+++ b/TrustKitTests/TSKEndToEndSwizzlingTests.m
@@ -167,7 +167,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge * _Nonnull)challenge
               // Valid pinning configuration
               @"www.datatheorem.com" : @{
                       kTSKEnforcePinning : @YES,
-                      kTSKPublicKeyHashes : @[@"F6jTih9VkkYZS8yuYqeU/4DUGehJ+niBGkkQ1yg8H3U=", // CA key
+                      kTSKPublicKeyHashes : @[@"a4FoHyEnsFhauIx0w/gB7ywslD6tWGk83J2F6Pv1phA=", // CA key
                                               @"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" // Fake key
                                               ]},
               // Invalid pinning configuration


### PR DESCRIPTION
Ensure the "protected data availability" check performed by the SPKI cache always runs on the main thread. 

This addresses the problem noted here: https://github.com/datatheorem/TrustKit/pull/336#issuecomment-2412967210