### PR TITLE
Fix #351

### DIFF
--- a/TrustKit/Reporting/TSKBackgroundReporter.m
+++ b/TrustKit/Reporting/TSKBackgroundReporter.m
@@ -203,6 +203,12 @@ static NSString * const kTSKBackgroundSessionIdentifierFormat = @"%@.TSKBackgrou
         [NSException raise:@"TSKBackgroundReporter runtime error"
                     format:@"Report cannot be saved to file: %@", [error description]];
 #endif
+        // In production, if the report could not be written, bail out here. Otherwise we would go on to
+        // hand a non-existent file to -uploadTaskWithRequest:fromFile:, which throws an uncaught
+        // NSInvalidArgumentException ("Cannot read file at ...") and crashes the app.
+        // https://github.com/datatheorem/TrustKit/issues/351
+        TSKLog(@"Report for %@ could not be saved to file; skipping upload: %@", serverHostname, [error description]);
+        return;
     }
     TSKLog(@"Report for %@ created at: %@", serverHostname, [tmpFileURL path]);
     


### PR DESCRIPTION
### Crash

```
Fatal Exception: NSInvalidArgumentException
Cannot read file at file:///.../....tsk-report
```

## Root cause

`-[TSKBackgroundReporter pinValidationFailedForHostname:...]` writes the JSON pin-failure report to a temp file and then uploads it with `-[NSURLSession uploadTaskWithRequest:fromFile:]`.

If `writeToURL:options:error:` fails (e.g. the device storage is full), the failure was only treated as fatal in **DEBUG** builds (see the `#if DEBUG` guard added for #32). In a **production** build, execution fell through and still called `uploadTaskWithRequest:fromFile:` with a file that was never written. CFNetwork validates the file synchronously at task-creation time and throws an uncaught `NSInvalidArgumentException`, crashing the app — exactly at `TSKBackgroundReporter.m:218` in the reported stack trace.

`FirebasePerformance` appears in the trace only because it swizzles `uploadTaskWithRequest:fromFile:`; it is not the cause.

## Fix

Return early when the report file cannot be written, so the reporter never hands a non-existent file to the upload task. DEBUG builds still raise (unchanged), preserving the behavior from #32.