### PR TITLE
Fix -Werror build failure from unused isProtectedDataAvailableAsync

### DIFF
--- a/TrustKit/Pinning/TSKSPKIHashCache.m
+++ b/TrustKit/Pinning/TSKSPKIHashCache.m
@@ -163,17 +163,19 @@ static BOOL isProtectedDataAvailable(void)
     }
 }
 
+// Currently unused, but kept for an upcoming rewrite that will need an async variant.
+static void isProtectedDataAvailableAsync(dispatch_queue_t callbackQueue, void (^callback)(BOOL available)) __attribute__((unused));
 static void isProtectedDataAvailableAsync(dispatch_queue_t callbackQueue, void (^callback)(BOOL available))
 {
     NSCParameterAssert(callbackQueue);
     NSCParameterAssert(callback);
-    
+
     void (^callbackOnQueue)(BOOL) = ^(BOOL available) {
         dispatch_async(callbackQueue, ^{
             callback(available);
         });
     };
-    
+
     if (NSThread.isMainThread) {
         callbackOnQueue(_isProtectedDataAvailable());
     } else {


### PR DESCRIPTION
The Xcode 26 recommended project settings adopted in #355 enable `-Wunused-function` and treat warnings as errors. `isProtectedDataAvailableAsync` in `TSKSPKIHashCache.m` is defined but never called, so the iOS build now fails with:

```
TSKSPKIHashCache.m:166:13: error: unused function 'isProtectedDataAvailableAsync' [-Werror,-Wunused-function]
```

The function is intentionally kept for an upcoming rewrite, so rather than removing it this PR marks it `__attribute__((unused))` to silence the warning. Verified the `TrustKit` iOS scheme builds successfully afterward.